### PR TITLE
Fix typos, add clarity to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@ Using the example above, let's complete the following:
 1. Use a `grid` to put the `.logo` and `.nav-btn` into the same row. Align the logo to the left the button to the right.
     - This can be done using `text align` (left/right), or `justify-self` (start/end).
 2. Set the `.nav-menu` to span across two columns using `grid-column`
+
+```
+   ---------------------------
+   |   .logo   |  .nav-btn   |
+   ---------------------------
+   |        .nav-menu        |
+   ---------------------------
+```
+
 3. Create a `@media` query at `min-width: 640px` (or equivalent) and turn the `.lessons-grid` into a `grid` with a template of two columns.
 4. Apply a `grid-gap` of 1em (or equivalent) to the `.lessons-grid`.
     - Be sure to remove the margin on each `.lesson` to get an evenly spaced layout.
     - Note you could also go back and setup the `.lessons-grid` as a single-column grid (or no specified template) with grid-gap from the onset, to prevent having to override the margin. A grid-gap, in this example, can achieve the same spacing as the margin.
 5. Create a `@media` query at `min-width: 900px` (or equivalent) and turn the menu into something more suitable for a larger viewport, by:
     - Setting the `.nav-btn` to `display: none;` to remove it
-    - Ensuring the `.nav-block` only spans a single column
+    - Ensuring the `.header-block` only spans a single column
     - Setting all `.menu-item` elements to `display: inline-block;` (or, turn the `.mainmenu` into a `grid`!)
 
 ## On Your Own

--- a/css/main.css
+++ b/css/main.css
@@ -192,7 +192,7 @@ a {
     margin: 0 auto;
   }
 
-  .lesson-grid {
+  .lessons-grid {
     display: grid;
     /* 2 column template! (1 fraction each) */
     /* Use this as a guide:


### PR DESCRIPTION
This PR resolves two main issues:
- Typos
- Instruction clarity

## Typos
- `.nav-block` revised to `.header-block` since there are no elements with the class of `nav-block`
- `.lesson-grid` revised to `.lessons-grid`, there was a typo in the selector

## Instruction clarity
- Some students misinterpreted the spirit of `Task #2`. Instead of making a `grid-item` span across two cells, they created a sub-grid within its current cell with two columns in the sub-grid instead. I've added a supporting "image" to better demonstrate what the ask is. 